### PR TITLE
fixed the goto in vision example

### DIFF
--- a/examples/machine_vision/evaCamera.py
+++ b/examples/machine_vision/evaCamera.py
@@ -42,7 +42,7 @@ class EvaCamera:
         print(f'moving to item position {item_position}')
         with self.__eva.lock():
             to_item_joint_angles = self.__eva.calc_inverse_kinematics(POSE_GUESS, item_position, DEFAULT_END_EFFECTOR_ORIENTATION)
-            self.__eva.control_go_to(to_item_joint_angles)
+            self.__eva.control_go_to(to_item_joint_angles['ik']['joints'])
         
         print("in item position")        
 


### PR DESCRIPTION
Fixed the goto in vision example to use the joint angles from ik return value