### PR TITLE
Fixed redefinition of time in control_go_to

### DIFF
--- a/automata/Eva.py
+++ b/automata/Eva.py
@@ -162,9 +162,9 @@ class Eva:
         return self.__http_client.control_run(loop=1, wait_for_ready=True)
 
 
-    def control_go_to(self, joints, wait_for_ready=True, velocity=None, time=None):
+    def control_go_to(self, joints, wait_for_ready=True, velocity=None, duration=None):
         self.__logger.debug('Eva.control_go_to called')
-        return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, velocity=velocity, time=time)
+        return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, velocity=velocity, duration=duration)
 
 
     def control_pause(self, wait_for_paused=True):

--- a/automata/eva_http_client.py
+++ b/automata/eva_http_client.py
@@ -251,11 +251,11 @@ class EvaHTTPClient:
             self.control_wait_for(RobotState.READY)
 
 
-    def control_go_to(self, joints, wait_for_ready=True, velocity=None, time=None):
+    def control_go_to(self, joints, wait_for_ready=True, velocity=None, duration=None):
         if velocity is not None:
             body = json.dumps({'joints': joints, 'velocity': velocity})
-        elif time is not None:
-            body = json.dumps({'joints': joints, 'time': time})
+        elif duration is not None:
+            body = json.dumps({'joints': joints, 'time': duration})
         else:
             body = json.dumps({'joints': joints})
 


### PR DESCRIPTION
Imported module `time` was redefined in `Eva.control_go_to` as an optional argument to set the duration of the go-to movement, breaking the subsequent `time.sleep(0.1)`. Fixed by renaming argument to `duration`.