### PR TITLE
v3 control_run fix

### DIFF
--- a/automata/Eva.py
+++ b/automata/Eva.py
@@ -173,9 +173,9 @@ class Eva:
         return self.__http_client.control_home(wait_for_ready=wait_for_ready)
 
 
-    def control_run(self, loop=1, wait_for_ready=True):
+    def control_run(self, mode='teach', loop=1, wait_for_ready=True):
         self.__logger.debug('Eva.control_run called')
-        return self.__http_client.control_run(loop=loop, wait_for_ready=wait_for_ready)
+        return self.__http_client.control_run(mode=mode, loop=loop, wait_for_ready=wait_for_ready)
 
 
     def control_go_to(self, joints, wait_for_ready=True, velocity=None, duration=None):

--- a/automata/eva_http_client.py
+++ b/automata/eva_http_client.py
@@ -310,8 +310,8 @@ class EvaHTTPClient:
             self.control_wait_for(RobotState.READY)
 
 
-    def control_run(self, loop=1, wait_for_ready=True):
-        r = self.api_call_with_auth('POST', 'controls/run', json.dumps({'loop': loop}))
+    def control_run(self, mode='teach', loop=1, wait_for_ready=True):
+        r = self.api_call_with_auth('POST', 'controls/run', json.dumps({'mode': mode, 'loop': loop}))
         if r.status_code != 200:
             time.sleep(0.1)     # sleep for small period to avoid race condition between updating cache and reading state
             eva_error('control_run error', r)


### PR DESCRIPTION
V3 SDK control_run is broken because it doesn't supply a run mode (teach or automatic) within the payload. Fixed by adding a mode argument that defaults to teach to the functions and payload.