### PR TITLE
Automatically push to PyPI when creating a release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+name: Publish on release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel
+    - name: Build
+      env:
+        VERSION_RAW: ${{ github.ref }}
+      # Transform refs/tags/v0.0.2a01 to 0.0.2a01 and inject it into setup.py
+      run: |
+        export VERSION=`echo $VERSION_RAW | sed -E 's;.*/v(.*)$;\1;'`
+        sed -i 's/%VERSION%/'$VERSION'/' setup.py
+        python setup.py sdist bdist_wheel
+    - name: Publish a Python distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='evasdk',
-    version='0.0.1',
+    version='%VERSION%',
     description='SDK for the Automata Eva robotic arm',
     author='Automata',
     license='Apache License 2.0',


### PR DESCRIPTION
The release expects a name following the format `vX.Y` where `X.Y` is a PEP440 version number.

This PR is based on #25 and should be reviewed after it's merged.