### PR TITLE
Eva 'run' & 'go to' methods now use the correct renew period for the passed run mode.

### DIFF
--- a/evasdk/Eva.py
+++ b/evasdk/Eva.py
@@ -168,12 +168,20 @@ class Eva:
 
     def control_run(self, loop=1, wait_for_ready=True, mode='teach'):
         self.__logger.debug('Eva.control_run called')
-        return self.__http_client.control_run(loop=loop, wait_for_ready=wait_for_ready, mode=mode)
+        if mode == 'teach':
+            with self.__eva_locker.set_renew_period(3):
+                return self.__http_client.control_run(loop=loop, wait_for_ready=wait_for_ready, mode=mode)
+        else:
+            return self.__http_client.control_run(loop=loop, wait_for_ready=wait_for_ready, mode=mode)
 
 
     def control_go_to(self, joints, wait_for_ready=True, velocity=None, duration=None, mode='teach'):
-        self.__logger.debug('Eva.control_go_to called')
-        return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, velocity=velocity, duration=duration, mode=mode)
+        self.__logger.info('Eva.control_go_to called')
+        if mode == 'teach':
+            with self.__eva_locker.set_renew_period(3):
+                return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, velocity=velocity, duration=duration, mode=mode)
+        else:
+            return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, velocity=velocity, duration=duration, mode=mode)
 
 
     def control_pause(self, wait_for_paused=True):

--- a/evasdk/Eva.py
+++ b/evasdk/Eva.py
@@ -24,6 +24,10 @@ class Eva:
         self.__http_client.request_timeout = request_timeout
 
 
+    # ---------------------------------------------- Constants ----------------------------------------------
+    __TEACH_RENEW_PERIOD = 3
+
+
     # --------------------------------------------- Lock Holder ---------------------------------------------
     def __enter__(self):
         self.__eva_locker.__enter__()
@@ -169,7 +173,7 @@ class Eva:
     def control_run(self, loop=1, wait_for_ready=True, mode='teach'):
         self.__logger.debug('Eva.control_run called')
         if mode == 'teach':
-            with self.__eva_locker.set_renew_period(3):
+            with self.__eva_locker.set_renew_period(Eva.__TEACH_RENEW_PERIOD):
                 return self.__http_client.control_run(loop=loop, wait_for_ready=wait_for_ready, mode=mode)
         else:
             return self.__http_client.control_run(loop=loop, wait_for_ready=wait_for_ready, mode=mode)
@@ -178,7 +182,7 @@ class Eva:
     def control_go_to(self, joints, wait_for_ready=True, velocity=None, duration=None, mode='teach'):
         self.__logger.info('Eva.control_go_to called')
         if mode == 'teach':
-            with self.__eva_locker.set_renew_period(3):
+            with self.__eva_locker.set_renew_period(Eva.__TEACH_RENEW_PERIOD):
                 return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, velocity=velocity, duration=duration, mode=mode)
         else:
             return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, velocity=velocity, duration=duration, mode=mode)

--- a/evasdk/eva_locker.py
+++ b/evasdk/eva_locker.py
@@ -2,50 +2,95 @@ import threading
 
 from .eva_errors import EvaLockError
 
+# TODO improve timing accuracy by taking into account lock_renew() API call duration in the __renewal_timer() loop
+# TODO properly handle exceptions thrown in the renewal thread
+# TODO properly handle unlock on program exit
 
 class EvaWithLocker:
     """
-    The EvaWithLocker class is used to keep an Eva locked for the entirety of a Python with scope.
+    The EvaWithLocker class is used to keep an Eva locked for the entirety of a Python 'with' scope.
     It expects an already locked Eva object to be passed in, and for the duration of the
-    with scope it will renew the lock every <renew_period> seconds. At the end of the scope
+    with scope it will renew the lock every <renew_period> seconds. 
+
+    'with' scopes can be nested, with the lock being renewed in a particular
+    scope for the currently set 'renew_period' of the locker. At the end of the outer-most scope
     it will release the lock.
     """
-    def __init__(self, eva, renew_period=30):
+
+
+    def __init__(self, eva, fallback_renew_period=30):
         self.__eva = eva
-        self.__renew_period = renew_period
-        self.__locked = False
+        self.__fallback_renew_period = fallback_renew_period
+        self.__renew_period = fallback_renew_period
+        self.__period_stack = []
         self.__thread = None
         self.__cond = None
 
 
+    def set_renew_period(self, renew_period=None):
+        if renew_period == None:
+            self.__renew_period = self.__fallback_renew_period
+        else:
+            self.__renew_period = renew_period
+        return self
+
+
     def __enter__(self):
-        if self.__locked:
-            raise EvaLockError('Eva already locked in another "with" statement scope')
+        if len(self.__period_stack) == 0:
+            self.__try_renew()
 
-        try:
-            self.__eva.lock_renew()
-        except Exception:
-            raise EvaLockError('"with eva:" statement requires a locked eva object, try "with eva.lock():"')
+            self.__cond = threading.Condition()
+            self.__thread = threading.Thread(target=self.__renewal_timer)
 
-        self.__locked = True
-        self.__cond = threading.Condition()
-        self.__thread = threading.Thread(target=self.__start_loop)
-        self.__thread.start()
+            self.__period_stack.append(self.__renew_period)
+            self.__thread.start()
+        else:
+            with self.__cond:
+                if self.__renew_period != self.__period_stack[-1]:
+                    self.__try_renew()
+
+                    self.__period_stack.append(self.__renew_period)
+                    self.__reset_timer()
+                else:
+                    raise EvaLockError("""Unneccesary refresh of the lock renewal process,
+                 lock is already being renewed with the configured period.""")
 
 
     def __exit__(self, type, value, traceback):
+        context_end_size = None
+        
         with self.__cond:
-            self.__locked = False
-            self.__cond.notify_all()
-        self.__thread.join()
+            self.__period_stack.pop()
+            self.__reset_timer()
+
+            context_end_size = len(self.__period_stack)
+            if context_end_size != 0:
+                self.__try_renew()
+
+        if context_end_size == 0:
+            self.__thread.join()
+            self.set_renew_period()
 
 
-    def __start_loop(self):
-        while True:
-            with self.__cond:
-                self.__cond.wait(timeout=self.__renew_period)
-            if self.__locked:
-                self.__eva.lock_renew()
-            else:
-                self.__eva.unlock()
-                return
+    def __renewal_timer(self):
+        with self.__cond:
+            while True:
+                if not self.__cond.wait(timeout=self.__period_stack[-1]):
+                    # timeout has occurred: renewing
+                    self.__eva.lock_renew()
+
+                if len(self.__period_stack) == 0:
+                    self.__eva.unlock()
+                    return
+
+
+    def __try_renew(self):
+        try:
+            self.__eva.lock_renew()
+        except Exception:
+            raise EvaLockError("""'with eva:' context statements require a locked eva object, e.g. by using 'with eva.lock():',
+             and not unlocking from within the statement.""")
+
+
+    def __reset_timer(self):
+        self.__cond.notify()

--- a/evasdk/eva_locker.py
+++ b/evasdk/eva_locker.py
@@ -6,11 +6,12 @@ from .eva_errors import EvaLockError
 # TODO properly handle exceptions thrown in the renewal thread
 # TODO properly handle unlock on program exit
 
+
 class EvaWithLocker:
     """
     The EvaWithLocker class is used to keep an Eva locked for the entirety of a Python 'with' scope.
     It expects an already locked Eva object to be passed in, and for the duration of the
-    with scope it will renew the lock every <renew_period> seconds. 
+    with scope it will renew the lock every <renew_period> seconds.
 
     'with' scopes can be nested, with the lock being renewed in a particular
     scope for the currently set 'renew_period' of the locker. At the end of the outer-most scope
@@ -28,7 +29,7 @@ class EvaWithLocker:
 
 
     def set_renew_period(self, renew_period=None):
-        if renew_period == None:
+        if renew_period is None:
             self.__renew_period = self.__fallback_renew_period
         else:
             self.__renew_period = renew_period
@@ -58,7 +59,7 @@ class EvaWithLocker:
 
     def __exit__(self, type, value, traceback):
         context_end_size = None
-        
+
         with self.__cond:
             self.__period_stack.pop()
             self.__reset_timer()

--- a/tests/eva_locker_test.py
+++ b/tests/eva_locker_test.py
@@ -35,41 +35,208 @@ class TestEvaWithLocker(unittest.TestCase):
             self.fail("should not raise an exception")
 
         self.mock.lock.assert_not_called()
-        self.mock.unlock.assert_called_once()
         self.mock.lock_renew.assert_called_once()
+        self.mock.unlock.assert_called_once()
 
 
     def test_lock_with_renew(self):
         try:
             with self.testEvaWithLocker:
-                time.sleep(0.02)
+                time.sleep(0.015)
         except Exception:
             self.fail("should not raise an exception")
 
         self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 2)
         self.mock.unlock.assert_called_once()
-        assert self.mock.lock_renew.call_count == 2
-
-
-    def test_double_lock_should_raise(self):
-        with self.assertRaises(Exception):
-            with self.testEvaWithLocker:
-                with self.testEvaWithLocker:
-                    self.fail("did not raise exception when locking an already locked Eva")
-        self.mock.lock.assert_not_called()
-        self.mock.unlock.assert_called_once()
-        self.mock.lock_renew.assert_called_once()
 
 
     def test_not_locked_should_raise(self):
-        self.mock.lock_renew.side_effect = Exception("can't renew a unlocked eva")
+        self.mock.lock_renew.side_effect = Exception("can't renew an unlocked eva")
 
         with self.assertRaises(Exception):
             with self.testEvaWithLocker:
                 self.fail("did not raise exception when renewing a not locked Eva")
+
         self.mock.lock.assert_not_called()
-        self.mock.unlock.assert_not_called()
         self.mock.lock_renew.assert_called_once()
+        self.mock.unlock.assert_not_called()
+
+
+    def test_nested_locker_same_period_should_raise(self):
+        with self.assertRaises(Exception):
+            with self.testEvaWithLocker:
+                with self.testEvaWithLocker:
+                    self.fail("did not raise exception when locking an already locked Eva")
+
+        self.mock.lock.assert_not_called()
+        self.mock.lock_renew.assert_called_once()
+        self.mock.unlock.assert_called_once()
+
+
+    def test_nested_locker_entry_and_exit_renews_lock(self):
+        try:
+            with self.testEvaWithLocker:
+                with self.testEvaWithLocker.set_renew_period(1):
+                    pass
+        except Exception:
+            self.fail("should not raise an exception")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 3)
+        self.mock.unlock.assert_called_once()
+
+
+    def test_nested_locker_different_period_with_inner_renew(self):
+        try:
+            with self.testEvaWithLocker:
+                time.sleep(0.005)
+                with self.testEvaWithLocker.set_renew_period(0.05):
+                    time.sleep(0.09)
+        except Exception:
+            self.fail("should not raise an exception")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 4)
+        self.mock.unlock.assert_called_once()
+
+
+    def test_nested_locker_different_period_with_outer_renew(self):
+        try:
+            with self.testEvaWithLocker:
+                with self.testEvaWithLocker.set_renew_period(0.1):
+                    time.sleep(0.01)
+                time.sleep(0.015)
+        except Exception:
+            self.fail("should not raise an exception")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 4)
+        self.mock.unlock.assert_called_once()
+
+
+    def test_nested_locker_reset_on_outer_exit(self):
+        try:
+            # 3 renews from this context
+            with self.testEvaWithLocker:
+                with self.testEvaWithLocker.set_renew_period(0.1):
+                    pass
+
+            with self.testEvaWithLocker:
+                # Sleep duration < 0.1s should still cause a renew
+                time.sleep(0.015)
+        except Exception:
+            self.fail("should not raise an exception")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 5)
+        self.assertEqual(self.mock.unlock.call_count, 2)
+
+
+    def test_deeply_nested_contexts(self):
+        try:
+            with self.testEvaWithLocker:
+                with self.testEvaWithLocker.set_renew_period(0.3):
+                    with self.testEvaWithLocker.set_renew_period(0.45):
+                        with self.testEvaWithLocker.set_renew_period(0.075):
+                            # Sleep duration should cause a renew here
+                            time.sleep(0.078)
+        except Exception:
+            self.fail("should not raise an exception")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 8)
+        self.mock.unlock.assert_called_once()
+
+
+    def test_locker_has_default_period(self):
+        self.testEvaWithLocker = EvaWithLocker(self.mock)
+
+        try:
+            with self.testEvaWithLocker:
+                # To avoid long tests: Sleep duration shorter than
+                # the relatively long default should not cause a renew here
+                time.sleep(0.5)
+        except Exception:
+            self.fail("should not raise an exception")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 1)
+        self.mock.unlock.assert_called_once()
+
+
+    def test_can_set_period_to_default(self):
+        try:
+            with self.testEvaWithLocker:
+                with self.testEvaWithLocker.set_renew_period(1):
+                    with self.testEvaWithLocker.set_renew_period():
+                        # Sleep duration should cause a renew here
+                        time.sleep(0.011)
+        except Exception:
+            self.fail("should not raise an exception")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 6)
+        self.mock.unlock.assert_called_once()
+
+
+    def test_nested_locker_uses_last_set_period(self):
+        try:
+            with self.testEvaWithLocker:
+                self.testEvaWithLocker.set_renew_period(0.02)
+                with self.testEvaWithLocker.set_renew_period(0.1):
+                    # Sleep duration should not cause a renew here
+                    time.sleep(0.05)
+        except Exception:
+            self.fail("should not raise an exception")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 3)
+        self.mock.unlock.assert_called_once()
+
+
+    def test_nested_locker_returns_to_parent_period(self):
+        try:
+            with self.testEvaWithLocker:
+                # Each sleep duration should cause a single renew here
+                with self.testEvaWithLocker.set_renew_period(0.1):
+                    time.sleep(0.11)
+                time.sleep(0.011)
+        except Exception:
+            self.fail("should not raise an exception")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 5)
+        self.mock.unlock.assert_called_once()
+
+
+    def test_handles_nested_renew_failure_on_enter(self):
+        self.mock.lock_renew.side_effect = [None, Exception("Lock could not be renewed")]
+
+        with self.assertRaises(Exception):
+            with self.testEvaWithLocker:
+                with self.testEvaWithLocker.set_renew_period(0.1):
+                    self.fail("did not raise exception when renewing a not locked Eva")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 2)
+        # Should have final unlock
+        self.mock.unlock.assert_called_once()
+
+
+    def test_handles_nested_renew_failure_on_exit(self):
+        self.mock.lock_renew.side_effect = [None, None, Exception("Lock could not be renewed")]
+
+        with self.assertRaises(Exception):
+            with self.testEvaWithLocker:
+                with self.testEvaWithLocker.set_renew_period(0.1):
+                    pass
+                self.fail("did not raise exception when renewing a not locked Eva")
+
+        self.mock.lock.assert_not_called()
+        self.assertEqual(self.mock.lock_renew.call_count, 3)
+        # Should have final unlock
+        self.mock.unlock.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/tests/eva_locker_test.py
+++ b/tests/eva_locker_test.py
@@ -4,6 +4,7 @@ import time
 
 
 from evasdk.eva_locker import EvaWithLocker
+from evasdk.eva_errors import EvaLockError
 
 
 class MockEva():
@@ -64,7 +65,7 @@ class TestEvaWithLocker(unittest.TestCase):
 
 
     def test_nested_locker_same_period_should_raise(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(EvaLockError):
             with self.testEvaWithLocker:
                 with self.testEvaWithLocker:
                     self.fail("did not raise exception when locking an already locked Eva")


### PR DESCRIPTION

* Allow nested locker contexts to temporarily set new renew period
* Added more locker tests