### PR TITLE
issue #49: fixed the arguement names for control_go_to

### DIFF
--- a/evasdk/Eva.py
+++ b/evasdk/Eva.py
@@ -180,13 +180,13 @@ class Eva:
             return self.__http_client.control_run(loop=loop, wait_for_ready=wait_for_ready, mode=mode)
 
 
-    def control_go_to(self, joints, wait_for_ready=True, max_speed=None, time=None, mode='teach'):
+    def control_go_to(self, joints, wait_for_ready=True, max_speed=None, time_sec=None, mode='teach'):
         self.__logger.info('Eva.control_go_to called')
         if mode == 'teach':
             with self.__eva_locker.set_renew_period(Eva.__TEACH_RENEW_PERIOD):
-                return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed, time=time, mode=mode)
+                return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed, time_sec=time_sec, mode=mode)
         else:
-            return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed, time=time, mode=mode)
+            return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed, time_sec=time_sec, mode=mode)
 
 
     def control_pause(self, wait_for_paused=True):

--- a/evasdk/Eva.py
+++ b/evasdk/Eva.py
@@ -180,13 +180,13 @@ class Eva:
             return self.__http_client.control_run(loop=loop, wait_for_ready=wait_for_ready, mode=mode)
 
 
-    def control_go_to(self, joints, wait_for_ready=True, velocity=None, duration=None, mode='teach'):
+    def control_go_to(self, joints, wait_for_ready=True, max_speed=None, time=None, mode='teach'):
         self.__logger.info('Eva.control_go_to called')
         if mode == 'teach':
             with self.__eva_locker.set_renew_period(Eva.__TEACH_RENEW_PERIOD):
-                return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, velocity=velocity, duration=duration, mode=mode)
+                return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed, time=time, mode=mode)
         else:
-            return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, velocity=velocity, duration=duration, mode=mode)
+            return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed, time=time, mode=mode)
 
 
     def control_pause(self, wait_for_paused=True):

--- a/evasdk/eva_http_client.py
+++ b/evasdk/eva_http_client.py
@@ -329,18 +329,18 @@ class EvaHTTPClient:
             self.control_wait_for(RobotState.READY)
 
 
-    def control_go_to(self, joints, wait_for_ready=True, max_speed=None, time=None, mode='teach'):
+    def control_go_to(self, joints, wait_for_ready=True, max_speed=None, time_sec=None, mode='teach'):
         body = {'joints': joints, 'mode': mode}
         if max_speed is not None:
             body['max_speed'] = max_speed
-        elif time is not None:
-            body['time'] = time
+        if time is not None:
+            body['time'] = time_sec
 
         r = self.api_call_with_auth('POST', 'controls/go_to', json.dumps(body))
         if r.status_code != 200:
             eva_error('control_go_to error', r)
         elif wait_for_ready:
-            time.sleep(0.1)     # sleep for small period to avoid race condition between updating cache and reading state
+            time.sleep(0.1)     # sleep for small period to avoid race condition between cache updating and reading state
             self.control_wait_for(RobotState.READY)
 
 

--- a/evasdk/eva_http_client.py
+++ b/evasdk/eva_http_client.py
@@ -328,12 +328,13 @@ class EvaHTTPClient:
             time.sleep(0.1)     # sleep for small period to avoid race condition between updating cache and reading state
             self.control_wait_for(RobotState.READY)
 
-    def control_go_to(self, joints, wait_for_ready=True, velocity=None, duration=None, mode='teach'):
+
+    def control_go_to(self, joints, wait_for_ready=True, max_speed=None, time=None, mode='teach'):
         body = {'joints': joints, 'mode': mode}
-        if velocity is not None:
-            body['velocity'] = velocity
-        elif duration is not None:
-            body['time'] = duration
+        if max_speed is not None:
+            body['max_speed'] = max_speed
+        elif time is not None:
+            body['time'] = time
 
         r = self.api_call_with_auth('POST', 'controls/go_to', json.dumps(body))
         if r.status_code != 200:


### PR DESCRIPTION
#49 

Fixed the arg names for control_go_to to match the current API: https://automata.tech/docs/v/3.1.0/api/controls/#go-to