### PR TITLE
run github actions on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build and test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
At the moment, actions run on a push but for obvious reasons this does not affect forks. By allowing actions on PRs, we can allow public repositories to contribute while still running our per-requisite test.