### PR TITLE
API/SDK integration test setup

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,3 +13,6 @@ pytest = "*"
 "pytest-cov" = "*"
 
 [requires]
+
+[scripts]
+test = "python -m pytest tests/"

--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ $ python -m pytest tests/<test-name>_test.py
 # some test require supplying ip and token via the `--ip` and `--token` arguements
 $ python -m pytest evasdk/<test-name>_test.py --ip 172.16.16.2 --token abc-123-def-456
 
-# very long time duration tests are disabled by default, to include them add the `--runslow` flag
-$ python -m pytest evasdk/<test-name>_test.py --runslow
+# long duration tests and tests requiring a connected Eva are disabled by default,
+# to include them add the `--runslow` or --runrobot flags
+$ python -m pytest evasdk/<test-name>_test.py --runslow --runrobot
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -158,10 +158,17 @@ Please raise any bugs or feature requests as a Github issues. We also gratefully
 
 ```bash
 $ pipenv shell
-$ python -m pytest evasdk/<name-of-file-to-test>
+# to run a single test file
+$ python -m pytest tests/<test-name>_test.py
+
+# to run all test files in tests directory
+$ python -m pytest tests/<test-name>_test.py
 
 # some test require supplying ip and token via the `--ip` and `--token` arguements
-$ python -m pytest evasdk/<name-of-file-to-test> --ip 172.16.16.2 --token abc-123-def-456
+$ python -m pytest evasdk/<test-name>_test.py --ip 172.16.16.2 --token abc-123-def-456
+
+# very long time duration tests are disabled by default, to include them add the `--runslow` flag
+$ python -m pytest evasdk/<test-name>_test.py --runslow
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -157,19 +157,19 @@ Please raise any bugs or feature requests as a Github issues. We also gratefully
 ## Testing
 
 ```bash
-$ pipenv shell
-# to run a single test file
-$ python -m pytest tests/<test-name>_test.py
-
 # to run all test files in tests directory
+$ pipenv run test
+
+# or to run a single test file
+$ pipenv shell
 $ python -m pytest tests/<test-name>_test.py
 
 # some test require supplying ip and token via the `--ip` and `--token` arguements
-$ python -m pytest evasdk/<test-name>_test.py --ip 172.16.16.2 --token abc-123-def-456
+$ pipenv run test --ip 172.16.16.2 --token abc-123-def-456
 
 # long duration tests and tests requiring a connected Eva are disabled by default,
 # to include them add the `--runslow` or --runrobot flags
-$ python -m pytest evasdk/<test-name>_test.py --runslow --runrobot
+$ pipenv run test --runslow --runrobot
 ```
 
 ## License

--- a/tests/Eva_auth_test.py
+++ b/tests/Eva_auth_test.py
@@ -5,6 +5,7 @@ import pytest
 # TODO: this rely on having an actual robot, should be rewritten to be mockable
 
 
+@pytest.mark.robot_required
 class TestAuth:
     def test_create_new_session(self, eva):
         token = eva.auth_create_session()

--- a/tests/Eva_auth_test.py
+++ b/tests/Eva_auth_test.py
@@ -1,25 +1,8 @@
-from evasdk import Eva, EvaAutoRenewError, EvaError
+from evasdk import EvaAutoRenewError, EvaError
 import time
 import pytest
-import logging
 
 # TODO: this rely on having an actual robot, should be rewritten to be mockable
-
-
-@pytest.fixture(scope="module")
-def eva(ip, token):
-    e = Eva(ip, token, request_timeout=10, renew_period=2 * 60)
-    e._Eva__logger.setLevel(logging.DEBUG)
-    e._Eva__http_client._EvaHTTPClient__logger.setLevel(logging.DEBUG)
-    yield e
-    if e.lock_status()['status'] != 'unlocked':
-        e.unlock()
-
-
-@pytest.fixture
-def locked_eva(eva):
-    with eva.lock():
-        yield eva
 
 
 class TestAuth:
@@ -38,7 +21,7 @@ class TestAuth:
         eva.users_get()
         assert(token != eva._Eva__http_client.session_token)
 
-
+    @pytest.mark.slow
     def test_auto_renew_error(self, eva):
         api_token = eva._Eva__http_client.api_token
         eva._Eva__http_client.api_token = ''
@@ -69,7 +52,7 @@ class TestAuth:
         with eva.lock():
             eva.gpio_set('d1', not eva.gpio_get('d1', 'output'))
 
-
+    @pytest.mark.slow
     def test_auto_renew(self, locked_eva):
         for _ in range(7):
             locked_eva.gpio_set('d1', not locked_eva.gpio_get('d1', 'output'))

--- a/tests/Eva_data_test.py
+++ b/tests/Eva_data_test.py
@@ -2,6 +2,7 @@ from evasdk import EvaError
 import pytest
 
 
+@pytest.mark.robot_required
 class TestEva_Data:
     # TODO: we may want to check the structure of the snapshot JSON object
     def test_snapshot(self, eva):

--- a/tests/Eva_data_test.py
+++ b/tests/Eva_data_test.py
@@ -1,0 +1,26 @@
+from evasdk import EvaError
+import pytest
+
+
+class TestEva_Data:
+    # TODO: we may want to check the structure of the snapshot JSON object
+    def test_snapshot(self, eva):
+        snapshot = eva.data_snapshot()
+        assert(snapshot)
+        assert(snapshot['control']['loop_count'] >= 0)
+
+
+    def test_snapshot_property(self, eva):
+        control_snapshot = eva.data_snapshot_property('control')
+        assert(control_snapshot)
+        assert(control_snapshot['loop_count'] >= 0)
+
+
+    def test_data_snapshot_property_PropertNotPresent(self, eva):
+        with pytest.raises(EvaError):
+            eva.data_snapshot_property('rubbish_property')
+
+
+    def test_servo_positions(self, eva):
+        servo_positions = eva.data_servo_positions()
+        assert(len(servo_positions) == 6)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,8 @@ import logging
 def pytest_addoption(parser):
     parser.addoption("--ip", default='172.16.16.2', help="IP of the test robot, defaults to 172.16.16.2")
     parser.addoption("--token", default='', help="API token of the test robot")
-    parser.addoption(
-        "--runslow", action="store_true", default=False, help="run slow tests"
-    )
+    parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
+    parser.addoption("--runrobot", action="store_true", default=False, help="run tests that require a connected Eva")
 
 
 @pytest.fixture(scope="session")
@@ -23,16 +22,27 @@ def token(request):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "requires_robot: no mocks, needs a connected Eva to run")
 
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runslow"):
         # --runslow given in cli: do not skip slow tests
         return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+    else:
+        skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
+
+    if config.getoption("--runrobot"):
+        # --runrobot given in cli: do not skip tests where a connected Eva is required
+        return
+    else:
+        skip_robot_required = pytest.mark.skip(reason="need --runrobot option to run")
+        for item in items:
+            if "robot_required" in item.keywords:
+                item.add_marker(skip_robot_required)
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
+from evasdk import Eva
 import pytest
+import logging
 
 
 def pytest_addoption(parser):
     parser.addoption("--ip", default='172.16.16.2', help="IP of the test robot, defaults to 172.16.16.2")
     parser.addoption("--token", default='', help="API token of the test robot")
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
 
 
 @pytest.fixture(scope="session")
@@ -14,3 +19,33 @@ def ip(request):
 @pytest.fixture(scope="session")
 def token(request):
     return request.config.getoption("--token")
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
+@pytest.fixture(scope="module")
+def eva(ip, token):
+    e = Eva(ip, token, request_timeout=10, renew_period=2 * 60)
+    e._Eva__logger.setLevel(logging.DEBUG)
+    e._Eva__http_client._EvaHTTPClient__logger.setLevel(logging.DEBUG)
+    yield e
+    if e.lock_status()['status'] != 'unlocked':
+        e.unlock()
+
+
+@pytest.fixture
+def locked_eva(eva):
+    with eva.lock():
+        yield eva

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def token(request):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
-    config.addinivalue_line("markers", "requires_robot: no mocks, needs a connected Eva to run")
+    config.addinivalue_line("markers", "robot_required: no mocks, needs a connected Eva to run")
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
PR goal: Prepare the test/ directory for a full suite of API/SDK integration tests.

- Added test flags, you need to enable tests manually that require a connection to Eva or have a very long run duration. This is now done with the --runslow and --runrobot flags. Leaving these flags out will not run these tests by default
- Added the Eva_data_test.py as a small example of how I want to format the rest of the API/SDK integration level tests.
- Updated the docs with more test run script examples

Follow on PRs will include:
- Fixing the CI pipe so that it runs the test suite
- Adding the rest of the Eva_*_test.py tests for increased API/SDK integration testing coverage