### PR TITLE
Eva io get/set tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,19 +157,19 @@ Please raise any bugs or feature requests as a Github issues. We also gratefully
 ## Testing
 
 ```bash
-# to run all test files in tests directory
+# to run all test files in tests directory:
 $ pipenv run test
 
-# or to run a single test file
+# or to run a single test file:
 $ pipenv shell
 $ python -m pytest tests/<test-name>_test.py
 
-# some test require supplying ip and token via the `--ip` and `--token` arguements
+# some test require supplying ip and token via the `--ip` and `--token` arguements:
 $ pipenv run test --ip 172.16.16.2 --token abc-123-def-456
 
-# long duration tests and tests requiring a connected Eva are disabled by default,
-# to include them add the `--runslow` or --runrobot flags
-$ pipenv run test --runslow --runrobot
+# Tests requiring the robot or long amounts of time will not run by default,
+# these require flags to be enabled, a full list of flags is availble with the help flag:
+$ pipenv run test -h
 ```
 
 ## License

--- a/tests/Eva_gpio_test.py
+++ b/tests/Eva_gpio_test.py
@@ -1,0 +1,39 @@
+import pytest
+
+digital_inputs = [('d0', 'input'), ('d1', 'input'), ('d2', 'input'), ('d3', 'input'), ('ee_d0', 'input'), ('ee_d1', 'input')]
+digital_outputs = [('d0', 'output'), ('d1', 'output'), ('d2', 'output'), ('d3', 'output'), ('ee_d0', 'output'), ('ee_d1', 'output')]
+analog_inputs = [('ee_a0', 'input'), ('ee_a1', 'input')]
+IOs = digital_inputs + analog_inputs + digital_outputs
+# Not supported yet ('a0', 'input'), ('a1', 'input'), ('a0', 'output'), ('a1', 'output'), ('ee_a0', 'output'), ('ee_a1', 'output')
+
+
+@pytest.mark.robot_required
+class TestEva_GPIO:
+    def test_get(self, eva):
+        # For all io variations, if the key is not present an exception
+        # will be thrown so no assertions are required
+        for pin in IOs:
+            (pin_name, pin_type) = pin
+            eva.gpio_get(pin_name, pin_type)
+
+
+    def test_set(self, locked_eva):
+        # All outputs should be set-able and idempotent
+        for pin in digital_outputs:
+            (pin_name, _) = pin
+            locked_eva.gpio_set(pin_name, True)
+            locked_eva.gpio_set(pin_name, True)
+            locked_eva.gpio_set(pin_name, False)
+            locked_eva.gpio_set(pin_name, False)
+
+
+    @pytest.mark.io_loopback_required
+    def test_set_get(self, locked_eva):
+        digital_states = [True, False]
+        for state in digital_states:
+            for (pin_name, _) in digital_outputs:
+                locked_eva.gpio_set(pin_name, state)
+
+            for (pin_name, pin_type) in digital_inputs:
+                pin_state = locked_eva.gpio_get(pin_name, pin_type)
+                assert(pin_state == state)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,12 @@ def pytest_addoption(parser):
     parser.addoption("--token", default='', help="API token of the test robot")
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
     parser.addoption("--runrobot", action="store_true", default=False, help="run tests that require a connected Eva")
+    parser.addoption(
+        "--io_loopback",
+        action="store_true",
+        default=False,
+        help="run tests that require head and base IO loopback cables connected to Eva",
+    )
 
 
 @pytest.fixture(scope="session")
@@ -23,26 +29,34 @@ def token(request):
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line("markers", "robot_required: no mocks, needs a connected Eva to run")
+    config.addinivalue_line(
+        "markers",
+        "io_loopback_required: require head and base IO loopback cables connected to Eva",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        # --runslow given in cli: do not skip slow tests
-        return
-    else:
+    # --runslow given in cli: do not skip slow tests
+    if not config.getoption("--runslow"):
         skip_slow = pytest.mark.skip(reason="need --runslow option to run")
         for item in items:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
 
-    if config.getoption("--runrobot"):
-        # --runrobot given in cli: do not skip tests where a connected Eva is required
-        return
-    else:
+    # --runrobot given in cli: do not skip tests where a connected Eva is required
+    if not config.getoption("--runrobot"):
         skip_robot_required = pytest.mark.skip(reason="need --runrobot option to run")
         for item in items:
             if "robot_required" in item.keywords:
                 item.add_marker(skip_robot_required)
+
+    # --io_loopback given in cli: do not skip tests requiring
+    # attached base and ee IO loopback cables
+    if not config.getoption("--io_loopback"):
+        skip_io_loopback_required = pytest.mark.skip(reason="need --io_loopback option to run")
+        for item in items:
+            if "io_loopback_required" in item.keywords:
+                item.add_marker(skip_io_loopback_required)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Add SDK tests for Eva object's GPIO get and set methods:
- Added --io_loopback flag for tests that require a head and base io loopback cables
- Added IO tests for getting IO states and and setting digital outputs
- Added loopback tests for digital IO