### PR TITLE
updated docs with v4.0.0 compatability info

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ These can be used to interact directly with the HTTP and Websocket APIs. Useful 
 
 To determine which version of the SDK works with your Eva's software version number (found on the Choreograph config page), please use the following chart:
 
-| SDK Version | Supported Eva Version |
-| ----------- | --------------------- |
-| 1.0.0       | 2.0.0 - 2.1.2         |
-| 2.0.0       | 3.0.0 - 3.0.1         |
-| 3.0.0       | 3.1.0                 |
+| SDK Version   | Supported Eva Version |
+| ------------- | --------------------- |
+| 1.0.0         | 2.0.0 - 2.1.2         |
+| 2.0.0         | 3.0.0 - 3.0.1         |
+| 3.0.0 - 4.0.0 | 3.1.0                 |
 
 For more information on how to install a particular version of the SDK, please refer to the [Installation](#Installation) section. We use the [Semver](https://semver.org/) version numbering stratergy.
 


### PR DESCRIPTION
Small docs update for the next release. Here is the change log from [3.0.0 -> dev diff](https://github.com/automata-tech/eva_python_sdk/compare/v3.0.0...development):

- BREAKING CHANGE: Updated Classes Eva and EvaHTTPClient "control_go_to" methods to use arguements "max_speed" instead of "velocity" and "time_sec" instead of "duration"
- Fixed tests to run on CI runs
- Added a Pipfile "test" script with README examples
- Added pytest test fixtures that allow running tests against a connected Eva
- Added tests for GPIOs and the data snapshot


4.0.0 breaking change due to argument name change.

If approved and merged I'll release from this merge with 4.0.0 tag.
Thanks!