### PR TITLE
Add a way to discover Evas on your network programmatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,27 +12,31 @@ jobs:
         python-version: [3.5, 3.6, 3.7]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
     - name: Install dependencies
-      uses: "VaultVulp/action-pipenv@master"
+      uses: VaultVulp/action-pipenv@v2.0.1
       with:
         command: install --dev
     - name: Run linter
-      uses: "VaultVulp/action-pipenv@master"
+      uses: VaultVulp/action-pipenv@v2.0.1
       with:
-        command: run flake8
+        command: run lint
+    - name: Run type checker
+      uses: VaultVulp/action-pipenv@v2.0.1
+      with:
+        command: run type
     - name: Run tests
-      uses: "VaultVulp/action-pipenv@master"
+      uses: VaultVulp/action-pipenv@v2.0.1
       with:
         command: run test --cov=evasdk --cov-branch --cov-report=xml
     - name: Upload to codecov
-      uses: codecov/codecov-action@v1.0.3
+      uses: codecov/codecov-action@v1.0.7
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -20,21 +20,13 @@ jobs:
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
     - name: Install dependencies
-      uses: VaultVulp/action-pipenv@v2.0.1
-      with:
-        command: install --dev
+      run: pipenv install --dev --python ${{ matrix.python-version }}
     - name: Run linter
-      uses: VaultVulp/action-pipenv@v2.0.1
-      with:
-        command: run lint
-    - name: Run type checker
-      uses: VaultVulp/action-pipenv@v2.0.1
-      with:
-        command: run type
+      run: pipenv run lint
+    - name: Run type
+      run: pipenv run type
     - name: Run tests
-      uses: VaultVulp/action-pipenv@v2.0.1
-      with:
-        command: run test --cov=evasdk --cov-branch --cov-report=xml
+      run: pipenv run test --cov=evasdk --cov-branch --cov-report=xml
     - name: Upload to codecov
       uses: codecov/codecov-action@v1.0.7
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -27,7 +27,7 @@ jobs:
         sed -i 's/%VERSION%/'$VERSION'/' evasdk/version.py
         python setup.py sdist bdist_wheel
     - name: Publish a Python distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.3.0
       with:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 dist/
 .pytest_cache
 *coverage*
+.mypy_cache

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright 2018 Automata Technologies Ltd
+   Copyright 2015-2020 Automata Technologies Ltd
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 requests = "*"
 websockets = "*"
 zeroconf = "==0.27.1"
+dataclasses = "*"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -6,15 +6,21 @@ name = "pypi"
 [packages]
 requests = "*"
 websockets = "*"
+zeroconf = "==0.27.1"
 
 [dev-packages]
 flake8 = "*"
 requests-mock = "*"
 pytest = "*"
 "pytest-cov" = "*"
+"pytest-flake8" = "*"
+"pytest-mypy" = "*"
+mypy = "*"
 
 [requires]
 
 [scripts]
-test = "python -m pytest tests/"
+test = "pipenv run testd tests/"
+testd = "python -m pytest --mypy --flake8"
 lint = "flake8"
+type = "mypy evasdk examples tests"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cdf050f3dadb36bd3c27358d3028d141e3911b3b5560102ff5f7812d8dedae27"
+            "sha256": "5d82ae43792dea1e411198fb78cb278466b3f5b9997d1cc49172067e6fcb8516"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -34,6 +34,13 @@
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
             "version": "==2.10"
+        },
+        "ifaddr": {
+            "hashes": [
+                "sha256:1f9e8a6ca6f16db5a37d3356f07b6e52344f6f9f7e806d618537731669eb1a94",
+                "sha256:d1f603952f0a71c9ab4e705754511e4e03b02565bc4cec7188ad6415ff534cd3"
+            ],
+            "version": "==0.1.7"
         },
         "requests": {
             "hashes": [
@@ -77,6 +84,14 @@
             ],
             "index": "pypi",
             "version": "==8.1"
+        },
+        "zeroconf": {
+            "hashes": [
+                "sha256:1eac46908bf7d719b1d04c140b7a7ba995d2bc31f5a15d863f5b10da1b6a33b3",
+                "sha256:51a8bc581036cabcf82523c81b72f6a11b2c7913eb7eb418b6dad60cd40f9ef2"
+            ],
+            "index": "pypi",
+            "version": "==0.27.1"
         }
     },
     "develop": {
@@ -137,6 +152,13 @@
             ],
             "version": "==5.1"
         },
+        "filelock": {
+            "hashes": [
+                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
+                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
+            ],
+            "version": "==3.0.12"
+        },
         "flake8": {
             "hashes": [
                 "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c",
@@ -173,6 +195,33 @@
                 "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"
             ],
             "version": "==8.4.0"
+        },
+        "mypy": {
+            "hashes": [
+                "sha256:2c6cde8aa3426c1682d35190b59b71f661237d74b053822ea3d748e2c9578a7c",
+                "sha256:3fdda71c067d3ddfb21da4b80e2686b71e9e5c72cca65fa216d207a358827f86",
+                "sha256:5dd13ff1f2a97f94540fd37a49e5d255950ebcdf446fb597463a40d0df3fac8b",
+                "sha256:6731603dfe0ce4352c555c6284c6db0dc935b685e9ce2e4cf220abe1e14386fd",
+                "sha256:6bb93479caa6619d21d6e7160c552c1193f6952f0668cdda2f851156e85186fc",
+                "sha256:81c7908b94239c4010e16642c9102bfc958ab14e36048fa77d0be3289dda76ea",
+                "sha256:9c7a9a7ceb2871ba4bac1cf7217a7dd9ccd44c27c2950edbc6dc08530f32ad4e",
+                "sha256:a4a2cbcfc4cbf45cd126f531dedda8485671545b43107ded25ce952aac6fb308",
+                "sha256:b7fbfabdbcc78c4f6fc4712544b9b0d6bf171069c6e0e3cb82440dd10ced3406",
+                "sha256:c05b9e4fb1d8a41d41dec8786c94f3b95d3c5f528298d769eb8e73d293abc48d",
+                "sha256:d7df6eddb6054d21ca4d3c6249cae5578cb4602951fd2b6ee2f5510ffb098707",
+                "sha256:e0b61738ab504e656d1fe4ff0c0601387a5489ca122d55390ade31f9ca0e252d",
+                "sha256:eff7d4a85e9eea55afa34888dfeaccde99e7520b51f867ac28a48492c0b1130c",
+                "sha256:f05644db6779387ccdb468cc47a44b4356fc2ffa9287135d05b70a98dc83b89a"
+            ],
+            "index": "pypi",
+            "version": "==0.782"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
         },
         "packaging": {
             "hashes": [
@@ -232,6 +281,22 @@
             "index": "pypi",
             "version": "==2.10.0"
         },
+        "pytest-flake8": {
+            "hashes": [
+                "sha256:1b82bb58c88eb1db40524018d3fcfd0424575029703b4e2d8e3ee873f2b17027",
+                "sha256:2e91578ecd9b200066f99c1e1de0f510fbb85bcf43712d46ea29fe47607cc234"
+            ],
+            "index": "pypi",
+            "version": "==1.0.6"
+        },
+        "pytest-mypy": {
+            "hashes": [
+                "sha256:2560a9b27d59bb17810d12ec3402dfc7c8e100e40539a70d2814bcbb27240f27",
+                "sha256:76e705cfd3800bf2b534738e792245ac5bb8d780698d0f8cd6c79032cc5e9923"
+            ],
+            "index": "pypi",
+            "version": "==0.6.2"
+        },
         "requests": {
             "hashes": [
                 "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b",
@@ -254,6 +319,40 @@
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
             "version": "==1.15.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "version": "==1.4.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:6e95524d8a547a91e08f404ae485bbb71962de46967e1b71a0cb89af24e761c5",
+                "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae",
+                "sha256:f8d2bd89d25bc39dabe7d23df520442fa1d8969b82544370e03d88b5a591c392"
+            ],
+            "version": "==3.7.4.2"
         },
         "urllib3": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ $ pipenv run test
 
 # or to run a single test file:
 $ pipenv shell
-$ python -m pytest tests/<test-name>_test.py
+$ pipenv run testd tests/<test-name>_test.py
 
 # some test require supplying ip and token via the `--ip` and `--token` arguements:
 $ pipenv run test --ip 172.16.16.2 --token abc-123-def-456

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ __* This SDK is currently in beta__
 
 __Requires Python 3, not compatible with Python 2__
 
+We support Python `3.6` and later.
+
 ### Pip
 
 Make sure you have Python3 and pip installed, then run the following command:

--- a/evasdk/EvaDiscoverer.py
+++ b/evasdk/EvaDiscoverer.py
@@ -1,0 +1,121 @@
+from typing import Callable
+from dataclasses import dataclass
+from threading import Condition
+from .Eva import Eva
+from zeroconf import ServiceBrowser, Zeroconf
+
+
+CHOREO_SERVICE = "_automata-eva._tcp.local."
+
+
+@dataclass
+class DiscoveredEva:
+    name: str
+    host: str
+
+    def connect(self, token) -> Eva:
+        return Eva(self.host, token)
+
+
+DiscoverCallback = Callable[[str, DiscoveredEva], None]
+
+
+class EvaDiscoverer:
+
+
+    def __init__(self, callback: DiscoverCallback, name: str = None):
+        self.name = name
+        self.callback = callback
+        self.zeroconf = None
+
+    def __enter__(self):
+        self.zeroconf = Zeroconf()
+        self.browser = ServiceBrowser(self.zeroconf, CHOREO_SERVICE, self)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.zeroconf.close()
+
+    def __get_eva(self, zeroconf: Zeroconf, service_type: str, service_name: str):
+        info = zeroconf.get_service_info(service_type, service_name)
+        if info is None:
+            return None
+        return DiscoveredEva(host=info.server, name=info.properties[b'name'].decode("utf-8"))
+
+    def __filter_name(self, eva):
+        return self.name is not None and self.name != eva.name
+
+    def add_service(self, zeroconf: Zeroconf, service_type: str, service_name: str):
+        eva = self.__get_eva(zeroconf, service_type, service_name)
+        if eva is None or self.__filter_name(eva):
+            return
+        self.callback('added', eva)
+
+    def remove_service(self, zeroconf: Zeroconf, service_type: str, service_name: str):
+        eva = self.__get_eva(zeroconf, service_type, service_name)
+        if eva is None or self.__filter_name(eva):
+            return
+        self.callback('removed', eva)
+
+
+def __find_evas(callback: DiscoverCallback, timeout: float, name: str = None, condition: Condition = None):
+    if condition is None:
+        condition = Condition()
+    with EvaDiscoverer(name=name, callback=callback):
+        with condition:
+            condition.wait(timeout=timeout)
+
+
+def find_evas(timeout: float = 5):
+    """Blocks for `timeout` seconds and returns a dictionary of DiscoveredEva (with their names as key) discovered in that time"""
+    evas = {}
+
+    def __callback(event: str, eva: DiscoveredEva):
+        if event == 'added':
+            evas[eva.name] = eva
+        elif event == 'deleted':
+            del evas[eva.name]
+
+    __find_evas(callback=__callback, timeout=timeout)
+    return evas
+
+
+def find_eva(name: str, timeout: float = 5):
+    """Blocks for a maximum of `timeout` seconds and returns a DiscoveredEva if a robot named `name` was found, or `None`"""
+    eva = None
+    cv = Condition()
+
+    def __callback(event: str, eva_found: DiscoveredEva):
+        nonlocal eva
+        if event == 'added':
+            eva = eva_found
+            with cv:
+                cv.notify()
+
+    __find_evas(name=name, callback=__callback, timeout=timeout, condition=cv)
+    return eva
+
+
+def find_first_eva(timeout: float = 5):
+    """Blocks for a maximum of `timeout` seconds and returns a DiscoveredEva if one was found, or `None`"""
+    eva = None
+    cv = Condition()
+
+    def __callback(event: str, eva_found: DiscoveredEva):
+        nonlocal eva
+        if event == 'added' and eva is None:
+            eva = eva_found
+            with cv:
+                cv.notify()
+
+    __find_evas(callback=__callback, timeout=timeout, condition=cv)
+    return eva
+
+
+def discover_evas(callback: DiscoverCallback):
+    """Returns a context that will discovers robots until exited
+
+    It will call `callback` with 2 arguments: the event (either `added` or `removed`) and a Discovered Eva object
+
+    Note that `callback` will be called from another thread so you will need to ensure any data accessed there is done in a thread-safe manner
+    """
+    return EvaDiscoverer(callback=callback)

--- a/evasdk/__init__.py
+++ b/evasdk/__init__.py
@@ -77,3 +77,7 @@ from .eva_errors import (
     EvaValidationError, EvaAuthError, EvaAutoRenewError,
     EvaAdminError, EvaServerError)
 from .version import __version__
+from .EvaDiscoverer import (
+    DiscoverCallback, DiscoveredEva,
+    find_evas, find_eva, find_first_eva, discover_evas,
+)

--- a/evasdk/eva_http_client.py
+++ b/evasdk/eva_http_client.py
@@ -186,7 +186,7 @@ class EvaHTTPClient:
     def __globals_editing(self, keys, values):
         data = {'changes': []}
         if (isinstance(keys, list) and isinstance(values, list)):
-            [data['changes'].append({'key': c[0], 'value': c[1]}) for c in zip(keys, values)]
+            data['changes'] = [{'key': k, 'value': v} for k, v in zip(keys, values)]
         else:
             data['changes'].append({'key': keys, 'value': values})
         data = json.dumps(data)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+
+[mypy-pytest.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,11 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=['requests', 'websockets'],
+    install_requires=[
+        'requests',
+        'websockets',
+        'zeroconf',
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setuptools.setup(
         'requests',
         'websockets',
         'zeroconf',
+        'dataclasses',
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/tests/Eva_discovery_test.py
+++ b/tests/Eva_discovery_test.py
@@ -1,0 +1,37 @@
+import pytest
+import time
+from evasdk import find_first_eva, find_eva, find_evas, discover_evas
+
+
+timeout = 1.5  # second
+
+
+@pytest.mark.robot_required
+class TestEva_Discovery:
+    def test_find_first(self):
+        assert(find_first_eva(timeout=timeout) is not None)
+
+    def test_find_named(self):
+        eva = find_first_eva(timeout=timeout)
+        assert(find_eva(eva.name, timeout=timeout) is not None)
+
+    def test_cannot_find_named(self):
+        assert(find_eva("Awesome London Charlie", timeout=timeout) is None)
+
+    def test_find_multiple(self):
+        evas = find_evas(timeout=timeout)
+        assert(len(evas.keys()) > 0)
+
+    def test_context(self):
+        events = []
+        with discover_evas(lambda event, eva: events.append((event, eva))):
+            time.sleep(timeout)
+        assert(len(events) > 0)
+        assert(events[0][0] == "added")
+        assert(events[0][1] is not None)
+
+    def test_connecting(self, token):
+        eva = find_first_eva(timeout=timeout)
+        assert(eva is not None)
+        actual_eva = eva.connect(token)
+        assert(actual_eva.lock_status()["owner"] is not None)


### PR DESCRIPTION
This PR adds 4 new functions dealing with zeroconf discoverability:
 * `find_first_eva`: returns the first Eva found on the network (or `None`)
 * `find_eva`: returns the Eva with the given name (or `None`)
 * `find_evas`: returns all the Evas on the network (or an empty dict)
 * `discover_evas`: returns a context that can be used to check for Evas in parallel (you are notified through a callback)

As this new file uses python typing, I also added `mypy` to the mix (I used `pytype` first but the fact it fails to install on Github Action because of missing python-devel and that it doesn't support 3.8 made me drop it). This means I added some new scripts and dependencies in `Pipfile` and also updated the `build.yml` (in a bid to make `pytype` to work, in vain).

The change in `__globals_editing` is due to `pytype` complaining about it, I do think it is more idiomatic Python now.