### PR TITLE
added rotation conventions to IK

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ requests = "*"
 websockets = "*"
 zeroconf = "==0.27.1"
 dataclasses = "*"
+pytransform3d = "*"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ requests = "*"
 websockets = "*"
 zeroconf = "==0.27.1"
 dataclasses = "*"
-pytransform3d = "*"
+pytransform3d = "==1.2.1"
 
 [dev-packages]
 flake8 = "*"

--- a/evasdk/Eva.py
+++ b/evasdk/Eva.py
@@ -14,7 +14,8 @@ class Eva:
     def __init__(self, host_ip, token, request_timeout=5, renew_period=60 * 20):
         parsed_host_ip = strip_ip(host_ip)
 
-        self.__http_client = EvaHTTPClient(parsed_host_ip, token, request_timeout=request_timeout, renew_period=renew_period)
+        self.__http_client = EvaHTTPClient(parsed_host_ip, token, request_timeout=request_timeout,
+                                           renew_period=renew_period)
         self.__logger = logging.getLogger('evasdk.Eva:{}'.format(host_ip))
 
         self.__eva_locker = EvaWithLocker(self)
@@ -41,11 +42,13 @@ class Eva:
     # --------------------------------------------- HTTP HANDLERS ---------------------------------------------
     def api_call_with_auth(self, method, path, payload=None, headers={}, timeout=None, version='v1'):
         self.__logger.debug('Eva.api_call_with_auth {} {}'.format(method, path))
-        return self.__http_client.api_call_with_auth(method, path, payload=payload, headers=headers, timeout=timeout, version=version)
+        return self.__http_client.api_call_with_auth(method, path, payload=payload, headers=headers, timeout=timeout,
+                                                     version=version)
 
     def api_call_no_auth(self, method, path, payload=None, headers={}, timeout=None, version='v1'):
         self.__logger.debug('Eva.api_call_no_auth {} {}'.format(method, path))
-        return self.__http_client.api_call_no_auth(method, path, payload=payload, headers=headers, timeout=timeout, version=version)
+        return self.__http_client.api_call_no_auth(method, path, payload=payload, headers=headers, timeout=timeout,
+                                                   version=version)
 
 
     # Global
@@ -197,9 +200,11 @@ class Eva:
         self.__logger.info('Eva.control_go_to called')
         if mode == 'teach':
             with self.__eva_locker.set_renew_period(Eva.__TEACH_RENEW_PERIOD):
-                return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed, time_sec=time_sec, mode=mode)
+                return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed,
+                                                        time_sec=time_sec, mode=mode)
         else:
-            return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed, time_sec=time_sec, mode=mode)
+            return self.__http_client.control_go_to(joints, wait_for_ready=wait_for_ready, max_speed=max_speed,
+                                                    time_sec=time_sec, mode=mode)
 
 
     def control_pause(self, wait_for_paused=True):
@@ -233,9 +238,11 @@ class Eva:
         return self.__http_client.calc_forward_kinematics(joints, fk_type=fk_type, tcp_config=tcp_config)
 
 
-    def calc_inverse_kinematics(self, guess, target_position, target_orientation, tcp_config=None, orientation_type=None):
+    def calc_inverse_kinematics(self, guess, target_position, target_orientation, tcp_config=None,
+                                orientation_type=None):
         self.__logger.debug('Eva.calc_inverse_kinematics called')
-        return self.__http_client.calc_inverse_kinematics(guess, target_position, target_orientation, tcp_config=tcp_config, orientation_type=orientation_type)
+        return self.__http_client.calc_inverse_kinematics(guess, target_position, target_orientation,
+                                                          tcp_config=tcp_config, orientation_type=orientation_type)
 
 
     def calc_nudge(self, joints, direction, offset, tcp_config=None):

--- a/evasdk/Eva.py
+++ b/evasdk/Eva.py
@@ -233,9 +233,9 @@ class Eva:
         return self.__http_client.calc_forward_kinematics(joints, fk_type=fk_type, tcp_config=tcp_config)
 
 
-    def calc_inverse_kinematics(self, guess, target_position, target_orientation, tcp_config=None):
+    def calc_inverse_kinematics(self, guess, target_position, target_orientation, tcp_config=None, orientation_type=None):
         self.__logger.debug('Eva.calc_inverse_kinematics called')
-        return self.__http_client.calc_inverse_kinematics(guess, target_position, target_orientation, tcp_config=tcp_config)
+        return self.__http_client.calc_inverse_kinematics(guess, target_position, target_orientation, tcp_config=tcp_config, orientation_type=orientation_type)
 
 
     def calc_nudge(self, joints, direction, offset, tcp_config=None):

--- a/evasdk/eva_http_client.py
+++ b/evasdk/eva_http_client.py
@@ -451,7 +451,7 @@ class EvaHTTPClient:
             ypr = [target_orientation['yaw'], target_orientation['pitch'], target_orientation['roll']]
             dcm = matrix_from_euler_zyx(ypr)
             result = quaternion_from_matrix(check_matrix(dcm))
-        elif orientation_type == 'quat' or orientation_type == None:
+        elif orientation_type == 'quat' or orientation_type is None:
             result = check_quaternion(
                 [target_orientation['w'], target_orientation['x'], target_orientation['y'], target_orientation['z']])
         else:

--- a/evasdk/eva_http_client.py
+++ b/evasdk/eva_http_client.py
@@ -432,7 +432,7 @@ class EvaHTTPClient:
         """
         End-effector orientation (target_orientation) can be provided in several standard formats,
         by specifying the orinetation_type (default is None):
-        - 'matrix': rotation matrix -> 3x3 array
+        - 'matrix': rotation matrix -> 3x3 array, in row major order
         - 'axis_angle': axis angle -> {'angle': float, 'x': float, 'y': float, 'z': float}
         - 'euler_zyx': {yaw, pitch, roll} Euler (Tait-Bryan) angles -> {'yaw': float, 'pitch': float, 'roll': float}
         - 'quat': quaternion -> {'w': float, 'x': float, 'y': float, 'z': float}

--- a/evasdk/eva_http_client.py
+++ b/evasdk/eva_http_client.py
@@ -2,8 +2,8 @@ import json
 import time
 import logging
 import requests
-from pytransform3d.rotations import *
-
+from pytransform3d.rotations import quaternion_from_matrix, quaternion_from_axis_angle, check_quaternion, \
+    check_axis_angle, check_matrix, matrix_from_euler_zyx
 from .robot_state import RobotState
 from .eva_errors import eva_error, EvaError, EvaAutoRenewError
 from .version import __version__

--- a/evasdk/eva_http_client.py
+++ b/evasdk/eva_http_client.py
@@ -2,8 +2,8 @@ import json
 import time
 import logging
 import requests
-from pytransform3d.rotations import quaternion_from_matrix, quaternion_from_axis_angle, check_quaternion, \
-    check_axis_angle, check_matrix, matrix_from_euler_zyx
+import pytransform3d.rotations as pyrot  # type: ignore
+
 from .robot_state import RobotState
 from .eva_errors import eva_error, EvaError, EvaAutoRenewError
 from .version import __version__
@@ -442,17 +442,17 @@ class EvaHTTPClient:
 
         if orientation_type == 'dcm':
             dcm = target_orientation['dcm']
-            result = quaternion_from_matrix(check_matrix(dcm))
+            result = pyrot.quaternion_from_matrix(pyrot.check_matrix(dcm))
         elif orientation_type == 'axis_angle':
             axis_angle = [target_orientation['x'], target_orientation['y'], target_orientation['z'],
                           target_orientation['angle']]
-            result = quaternion_from_axis_angle(check_axis_angle(axis_angle))
+            result = pyrot.quaternion_from_axis_angle(pyrot.check_axis_angle(axis_angle))
         elif orientation_type == 'ypr':
             ypr = [target_orientation['yaw'], target_orientation['pitch'], target_orientation['roll']]
-            dcm = matrix_from_euler_zyx(ypr)
-            result = quaternion_from_matrix(check_matrix(dcm))
+            dcm = pyrot.matrix_from_euler_zyx(ypr)
+            result = pyrot.quaternion_from_matrix(pyrot.check_matrix(dcm))
         elif orientation_type == 'quat' or orientation_type is None:
-            result = check_quaternion(
+            result = pyrot.check_quaternion(
                 [target_orientation['w'], target_orientation['x'], target_orientation['y'], target_orientation['z']])
         else:
             eva_error('calc_inverse_kinematics invalid "{}" orientation_type '.format(orientation_type))

--- a/evasdk/eva_http_client.py
+++ b/evasdk/eva_http_client.py
@@ -450,8 +450,8 @@ class EvaHTTPClient:
                           target_orientation['angle']]
             result = pyrot.quaternion_from_axis_angle(pyrot.check_axis_angle(axis_angle))
         elif orientation_type == 'euler_zyx':
-            ypr = [target_orientation['yaw'], target_orientation['pitch'], target_orientation['roll']]
-            matrix = pyrot.matrix_from_euler_zyx(ypr)
+            euler_zyx = [target_orientation['yaw'], target_orientation['pitch'], target_orientation['roll']]
+            matrix = pyrot.matrix_from_euler_zyx(euler_zyx)
             result = pyrot.quaternion_from_matrix(pyrot.check_matrix(matrix))
         elif orientation_type == 'quat' or orientation_type is None:
             result = pyrot.check_quaternion(

--- a/evasdk/eva_http_client.py
+++ b/evasdk/eva_http_client.py
@@ -432,7 +432,7 @@ class EvaHTTPClient:
         """
         End-effector orientation (target_orientation) can be provided in several standard formats,
         by specifying the orinetation_type (default is None):
-        - 'matrix': rotation matrix -> {'col_x': 1x3 float array, 'col_y': 1x3 float array, 'col_z': 1x3 float array}
+        - 'matrix': rotation matrix -> 3x3 array
         - 'axis_angle': axis angle -> {'angle': float, 'x': float, 'y': float, 'z': float}
         - 'euler_zyx': {yaw, pitch, roll} Euler (Tait-Bryan) angles -> {'yaw': float, 'pitch': float, 'roll': float}
         - 'quat': quaternion -> {'w': float, 'x': float, 'y': float, 'z': float}
@@ -443,9 +443,7 @@ class EvaHTTPClient:
         quat_not_normed = None
 
         if orientation_type == 'matrix':
-            matrix = [target_orientation['col_x'], target_orientation['col_y'], target_orientation['col_z']]
-            matrix_trans = [[matrix[j][i] for j in range(len(matrix))] for i in range(len(matrix[0]))]
-            quat_not_normed = pyrot.quaternion_from_matrix(pyrot.check_matrix(matrix_trans))
+            quat_not_normed = pyrot.quaternion_from_matrix(pyrot.check_matrix(target_orientation))
         elif orientation_type == 'axis_angle':
             axis_angle = [target_orientation['x'], target_orientation['y'], target_orientation['z'],
                           target_orientation['angle']]

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,6 @@
 
 [mypy-pytest.*]
 ignore_missing_imports = True
+
+[mypy-pytransform3d.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,3 @@
 
 [mypy-pytest.*]
 ignore_missing_imports = True
-
-[mypy-pytransform3d.*]
-ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
         'websockets',
         'zeroconf',
         'dataclasses',
+        'pytransform3d',
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR deals with the addition of standard rotation methods to the IK. In particular, on top the existing quaternion, the following have been added:
- rotation matrix
- axis angle
- yaw pitch and roll
If no orientation type is specified, the orientation will default to quaternion, hence maintaining the current behaviour of the method. 