### PR TITLE
fix: add back in requirements for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,3 +14,5 @@ sphinx:
 # RTD currently doesn't support pipenv (Pipfile) for listing the requirements.
 python:
    version: "3.6"
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+m2r2
+requests
+websockets
+zeroconf
+dataclasses


### PR DESCRIPTION
RTD requires deps in order to build the docs