### PR TITLE
feat: add semver to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ requests
 websockets
 zeroconf
 dataclasses
+semver


### PR DESCRIPTION
addressing an issue building docs
https://readthedocs.org/api/v2/build/14712282.txt
```
WARNING: autodoc: failed to import module 'Eva' from module 'evasdk'; the following exception was raised:
No module named 'semver'
WARNING: autodoc: failed to import module 'EvaDiscoverer' from module 'evasdk'; the following exception was raised:
No module named 'semver'
WARNING: autodoc: failed to import module 'eva_http_client' from module 'evasdk'; the following exception was raised:
No module named 'semver'
WARNING: autodoc: failed to import module 'eva_locker' from module 'evasdk'; the following exception was raised:
No module named 'semver'
WARNING: autodoc: failed to import module 'eva_ws' from module 'evasdk'; the following exception was raised:
No module named 'semver'
WARNING: autodoc: failed to import module 'observer' from module 'evasdk'; the following exception was raised:
No module named 'semver'
WARNING: autodoc: failed to import module 'version' from module 'evasdk'; the following exception was raised:
No module named 'semver'
WARNING: autodoc: failed to import module 'evasdk'; the following exception was raised:
No module named 'semver'
../README.md:3: WARNING: Duplicate explicit target name: "installation".
../README.md:85: WARNING: duplicate label examples, other instance in /home/docs/checkouts/readthedocs.org/user_builds/eva-python-sdk/checkouts/docs-development/docs/examples.rst
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [ 20%] evasdk
writing output... [ 40%] examples
writing output... [ 60%] index
```