### PR TITLE
fix: SemVer not installing on import

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,9 +10,9 @@ requests = "*"
 zeroconf = "*"
 types-dataclasses = "*"
 dataclasses = "*"
+semver = "*"
 # TODO: too big, install it manually if you want it
 #pytransform3d = "==1.2.1"
-semver = "*"
 
 [dev-packages]
 flake8 = "*"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     description='SDK for the Automata Eva robotic arm',
     author='Automata',
     license='Apache License 2.0',
-    author_email='charlie@automata.tech',
+    author_email='louis@automata.tech',
     url="https://github.com/automata-tech/eva_python_sdk",
     packages=setuptools.find_packages(),
     long_description=long_description,
@@ -21,6 +21,7 @@ setuptools.setup(
         'websocket-client',
         'zeroconf',
         'dataclasses',
+        'semver',
         # TODO: too big, install it manually if you want it
         # 'pytransform3d',
     ],
@@ -30,5 +31,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "License :: OSI Approved :: Apache Software License",
     ],
-    python_requires='>=3.0',
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
SemanticVersioning lib was not installing and had been raising errors on evasdk.Eva init as it was not specified within setup.py (install_requires).

Significant changes:
    Setuptools.py has been updated to specify the requirement of the semver lib.

Minor changes:
    Moved semver line in Pipfile to be above comments for readability.
    Appended email address in setup.py to be valid along with Python version requirement to be accurate.