### PR TITLE
feat: build documentation when tagging

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,3 +29,7 @@ jobs:
           git add .
           git commit -m 'docs'
           git push origin docs/${{ steps.get-git-tag.outputs.git-tag }} -f
+      - name: Trigger build of documentation
+        run: |
+          curl -X POST -H "Authorization: Token ${{ secrets.RTD_TOKEN }}" https://readthedocs.org/api/v3/projects/eva-python-sdk/versions/docs-${{ steps.get-git-tag.outputs.git-tag }}/builds/
+

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,4 +32,11 @@ jobs:
       - name: Trigger build of documentation
         run: |
           curl -X POST -H "Authorization: Token ${{ secrets.RTD_TOKEN }}" https://readthedocs.org/api/v3/projects/eva-python-sdk/versions/docs-${{ steps.get-git-tag.outputs.git-tag }}/builds/
+      - name: Make new documentation the default version
+        run: |
+          curl \
+            -X PATCH \
+            -H "Authorization: Token ${{ secrets.RTD_TOKEN }}" https://readthedocs.org/api/v3/projects/eva-python-sdk/ \
+            -H "Content-Type: application/json" \
+            -d '{"default_version": "docs-${{ steps.get-git-tag.outputs.git-tag }}"}'
 


### PR DESCRIPTION
Rather than relying on RTD's automation rules. We will trigger the build of the docs from the CI.
We are already doing this with dev docs and it works nicely.

Example HTTP req
```
❯ curl -X POST -H "Authorization: Token <TOKEN>" https://readthedocs.org/api/v3/projects/eva-python-sdk/versions/docs-v5.0.1/builds/
{"build":{"_links":{"_self":"https://readthedocs.org/api/v3/projects/eva-python-sdk/builds/15173533/","project":"https://readthedocs.org/api/v3/projects/eva-python-sdk/","version":"https://readthedocs.org/api/v3/projects/eva-python-sdk/versions/docs-v5.0.1/"},"commit":null,"created":"2021-11-03T16:43:57.979961Z","duration":null,"error":"","finished":null,"id":15173533,"project":"eva-python-sdk","state":{"code":"triggered","name":"Triggered"},"success":null,"urls":{"build":"https://readthedocs.org/projects/eva-python-sdk/builds/15173533/","project":"https://readthedocs.org/projects/eva-python-sdk/","version":"https://readthedocs.org/dashboard/eva-python-sdk/version/docs-v5.0.1/edit/"},"version":"docs-v5.0.1"},"project":{"_links":{"_self":"https://readthedocs.org/api/v3/projects/eva-python-sdk/","builds":"https://readthedocs.org/api/v3/projects/eva-python-sdk/builds/","environmentvariables":"https://readthedocs.org/api/v3/projects/eva-python-sdk/environmentvariables/","redirects":"https://readthedocs.org/api/v3/projects/eva-python-sdk/redirects/","subprojects":"https://readthedocs.org/api/v3/projects/eva-python-sdk/subprojects/","superproject":"https://readthedocs.org/api/v3/projects/eva-python-sdk/superproject/","translations":"https://readthedocs.org/api/v3/projects/eva-python-sdk/translations/","versions":"https://readthedocs.org/api/v3/projects/eva-python-sdk/versions/"},"created":"2021-05-18T14:33:48.234287Z","default_branch":"development","default_version":"docs-v5.0.1","homepage":null,"id":654177,"language":{"code":"en","name":"English"},"modified":"2021-11-03T16:42:01.707905Z","name":"Eva Python SDK","programming_language":{"code":"words","name":"Only Words"},"repository":{"type":"git","url":"https://github.com/automata-tech/eva_python_sdk"},"slug":"eva-python-sdk","subproject_of":null,"tags":[],"translation_of":null,"urls":{"builds":"https://readthedocs.org/projects/eva-python-sdk/builds/","documentation":"https://eva-python-sdk.readthedocs.io/en/docs-v5.0.1/","home":"https://readthedocs.org/projects/eva-python-sdk/","versions":"https://readthedocs.org/projects/eva-python-sdk/versions/"},"users":[{"username":"tomallpress"},{"username":"lbautomata"}]},"triggered":true,"version":{"_links":{"_self":"https://readthedocs.org/api/v3/projects/eva-python-sdk/versions/docs-v5.0.1/","builds":"https://readthedocs.org/api/v3/projects/eva-python-sdk/versions/docs-v5.0.1/builds/","project":"https://readthedocs.org/api/v3/projects/eva-python-sdk/"},"active":true,"built":true,"downloads":{},"hidden":false,"id":7493409,"identifier":"origin/docs/v5.0.1","ref":null,"slug":"docs-v5.0.1","type":"branch","urls":{"dashboard":{"edit":"https://readthedocs.org/dashboard/eva-python-sdk/version/docs-v5.0.1/edit/"},"documentation":"https://eva-python-sdk.readthedocs.io/en/docs-v5.0.1/","vcs":"https://github.com/automata-tech/eva_p~
```
https://eva-python-sdk.readthedocs.io/en/docs-v5.0.1/